### PR TITLE
Handle empty catch blocks

### DIFF
--- a/Buffs/BuffProfile.cs
+++ b/Buffs/BuffProfile.cs
@@ -74,7 +74,10 @@ namespace DoThingsBot.Buffs {
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Util.LogException(ex);
+            }
         }
 
         private void OnTreeStatsProfileComplete(IAsyncResult result) {
@@ -91,7 +94,10 @@ namespace DoThingsBot.Buffs {
 
                         isValid = true;
                     }
-                    catch (Exception ex) { }
+                    catch (Exception ex)
+                    {
+                        Util.LogException(ex);
+                    }
                 }
             }
             catch (Exception ex) {
@@ -327,7 +333,10 @@ namespace DoThingsBot.Buffs {
                             continue;
                         }
                     }
-                    catch (Exception ex) { }
+                    catch (Exception ex)
+                    {
+                        Util.LogException(ex);
+                    }
 
                     if (spellClass != Spells.SpellClass.UNKNOWN) {
                         if (!familyIds.Contains(spellClass)) {

--- a/Lib/UpdateChecker.cs
+++ b/Lib/UpdateChecker.cs
@@ -40,7 +40,10 @@ namespace DoThingsBot.Lib {
                     }
                 }
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                Util.LogException(ex);
+            }
         }
 
         private static void OnGitlabFetchComplete(IAsyncResult result) {

--- a/Util.cs
+++ b/Util.cs
@@ -225,7 +225,10 @@ namespace DoThingsBot
                             }
                         }
                     }
-                    catch (Exception ex) { }
+                    catch (Exception ex)
+                    {
+                        Util.LogException(ex);
+                    }
                 }
             }
             catch (Exception ex) { Util.LogException(ex); return false; }

--- a/Views/StatsView.cs
+++ b/Views/StatsView.cs
@@ -289,7 +289,10 @@ namespace DoThingsBot.Views {
             try {
                 control = (HudStaticText)view[viewKey];
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                Util.LogException(ex);
+            }
 
             var headerHeight = lineHeight;
 
@@ -332,7 +335,10 @@ namespace DoThingsBot.Views {
             try {
                 text = (HudStaticText)view[viewKey];
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                Util.LogException(ex);
+            }
 
             var rowHeight = lineHeight + 2;
 
@@ -393,7 +399,10 @@ namespace DoThingsBot.Views {
             try {
                 list = (HudList)view[viewKey];
             }
-            catch (Exception ex) { }
+            catch (Exception ex)
+            {
+                Util.LogException(ex);
+            }
 
             if (list == null) {
                 list = new HudList();

--- a/VirindiViews/Wrapper_WireupHelper.cs
+++ b/VirindiViews/Wrapper_WireupHelper.cs
@@ -251,7 +251,10 @@ namespace MyClasses.MetaViewWrappers
                         {
                             mycontrol = v[attr.Control];
                         }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            Util.LogException(ex);
+                        }
                         if (mycontrol != null)
                             break;
                     }
@@ -301,7 +304,10 @@ namespace MyClasses.MetaViewWrappers
                         {
                             mycontrol = v[attr.Control];
                         }
-                        catch { }
+                        catch (Exception ex)
+                        {
+                            Util.LogException(ex);
+                        }
                         if (mycontrol != null)
                             break;
                     }


### PR DESCRIPTION
## Summary
- log exceptions instead of swallowing them
- cover several files including BuffProfile, UpdateChecker, Util, StatsView and wrapper wireup