### PR TITLE
Remove BOM markers from source files

### DIFF
--- a/Buffs/BuffProfile.cs
+++ b/Buffs/BuffProfile.cs
@@ -1,4 +1,4 @@
-﻿using Decal.Adapter;
+using Decal.Adapter;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/FSM/Machine.cs
+++ b/FSM/Machine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Decal.Adapter.Wrappers;

--- a/Util.cs
+++ b/Util.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;


### PR DESCRIPTION
## Summary
- strip UTF-8 BOM markers from `Util.cs`, `FSM/Machine.cs`, and `Buffs/BuffProfile.cs`