### PR TITLE
Handle new spells without restart

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 CHANGELOG
+2.0.0.7
+* Detect newly learned spells without restarting the plugin.
 2.0.0.6
 * Add support for the following infinite rares:
   * Infinite Leather, Infinite Elaborate Dried Rations, Infinite Simple Dried Rations, Perennial Argenory Dye, Perennial Berimphur Dye, Perennial Botched Dye, Perennial Colban Dye, Perennial Hennacin Dye, Perennial Lapyan Dye, Perennial Minalim Dye, Perennial Relanim Dye, Perennial Thananim Dye, Perennial Verdalim Dye.

--- a/PluginCore.cs
+++ b/PluginCore.cs
@@ -52,9 +52,10 @@ namespace DoThingsBot {
 
                 CoreManager.Current.PluginInitComplete += new EventHandler<EventArgs>(Current_PluginInitComplete);
                 CoreManager.Current.CommandLineText += new EventHandler<ChatParserInterceptEventArgs>(Current_CommandLineText);
+                CoreManager.Current.CharacterFilter.SpellbookChanged += new EventHandler(Current_SpellbookChanged);
             }
-			catch (Exception ex) { Util.LogException(ex); }
-		}
+                        catch (Exception ex) { Util.LogException(ex); }
+                }
 
 		/// <summary>
 		/// This is called when the plugin is shut down. This happens only once.
@@ -64,6 +65,7 @@ namespace DoThingsBot {
 			try {
                 CoreManager.Current.PluginInitComplete -= new EventHandler<EventArgs>(Current_PluginInitComplete);
                 CoreManager.Current.CommandLineText -= new EventHandler<ChatParserInterceptEventArgs>(Current_CommandLineText);
+                CoreManager.Current.CharacterFilter.SpellbookChanged -= new EventHandler(Current_SpellbookChanged);
 
                 if (bot != null) bot.Dispose();
                 if (mainView != null) mainView.Dispose();
@@ -134,6 +136,13 @@ namespace DoThingsBot {
                 if (mainView != null) mainView.Dispose();
 
                 Util.WriteToDebugLog("Logoff");
+            }
+            catch (Exception ex) { Util.LogException(ex); }
+        }
+
+        void Current_SpellbookChanged(object sender, EventArgs e) {
+            try {
+                Spells.ClearSpellCaches();
             }
             catch (Exception ex) { Util.LogException(ex); }
         }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See [BUILDING.md](BUILDING.md) for prerequisites and detailed build steps.
  - TODO, but hopefully fairly self explanitory.
 
 # Known Issues
- - You must relog the bot after learning spells (from professors at least, untested with scrolls)
+ - The bot now detects newly learned spells without needing a relog.
  - The bot does not work if the ac window is minimized.  It does not have to be in focus.
 
 # Recipes

--- a/Spells.cs
+++ b/Spells.cs
@@ -376,6 +376,11 @@ namespace DoThingsBot {
         }
 
         private static Dictionary<SpellClass, Spell> exampleSpellClassCache = new Dictionary<SpellClass, Spell>();
+        
+        public static void ClearSpellCaches() {
+            exampleSpellClassCache.Clear();
+            _spellLevels.Clear();
+        }
 
         internal static Spell GetExampleSpellByClass(SpellClass family) {
             Spell exampleSpell = null;


### PR DESCRIPTION
## Summary
- refresh caches when spells are learned
- clear spell caches when Spellbook changes
- document fix for learning spells

## Testing
- `msbuild DoThingsBot.sln /p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8d279a808330913b32488d96df49